### PR TITLE
Fix issues to run tests on my own system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ all:
 
 clean:
 	rm -rf ca/cacert.pem ca/bad/cacert.pem ca/ec/cacert.pem ca/private/cacert.key ca/bad/private/cacert.key ca/ec/private/cacert.key
-	rm certs/*.cert certs/*.key
+	rm -f certs/*.cert certs/*.key
 	rm -rf ca/index.*
 
 killall:

--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ ca:	ca/cacert.pem ca/bad/cacert.pem ca/ec/cacert.pem
 certs: ca/cacert.pem ca/bad/cacert.pem ca/ec/cacert.pem intermediate test1 test2 test3 test4 \
 	test5 test6 test7 test8 test9 test10 test11 test12 test13 test14 test15 test16 test17 \
 	test20 test21 \
-	test22 test30 test31
+	test22 test30 test31 test32
 	@echo "✅  done!"
 
 ca/ec/cacert.pem:

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ all:
 
 clean:
 	rm -rf ca/cacert.pem ca/bad/cacert.pem ca/ec/cacert.pem ca/private/cacert.key ca/bad/private/cacert.key ca/ec/private/cacert.key
-	rm -rf certs/*
+	rm certs/*.cert certs/*.key
 	rm -rf ca/index.*
 
 killall:

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ all:
 	@echo " test<x>  Certificates for test #1 - like \"make test1\" "
 
 clean:
-	rm -rf ca/cacert.pem ca/bad/cacert.pem ca/private/cacert.key ca/bad/private/cacert.key
+	rm -rf ca/cacert.pem ca/bad/cacert.pem ca/ec/cacert.pem ca/private/cacert.key ca/bad/private/cacert.key ca/ec/private/cacert.key
 	rm -rf certs/*
 	rm -rf ca/index.*
 
@@ -96,12 +96,12 @@ web:
 #
 #	We also have five intermediate certificate authorities under the Standard CA, based on the one subsidary
 #
-ca:	ca/cacert.pem ca/ec/cacert.pem ca/bad/cacert.pem
+ca:	ca/cacert.pem ca/bad/cacert.pem ca/ec/cacert.pem
 	@echo "✅  done!"
 
 .PHONY=certs
 
-certs: ca/cacert.pem ca/bad/cacert.pem intermediate test1 test2 test3 test4 \
+certs: ca/cacert.pem ca/bad/cacert.pem ca/ec/cacert.pem intermediate test1 test2 test3 test4 \
 	test5 test6 test7 test8 test9 test10 test11 test12 test13 test14 test15 test16 test17 \
 	test20 test21 \
 	test22 test30 test31
@@ -433,7 +433,7 @@ test32: ca/ec/cacert.pem
 #test33:
 	# EC CA with strange curve
 
-alltests:	ca/cacert.pem	ca/bad/cacert.pem
+alltests:	ca/cacert.pem ca/bad/cacert.pem ca/ec/cacert.pem
 	@echo `date` > /tmp/testresult
 	@echo "get / HTTP/1.0" |$(OPENSSL) s_client -connect test1.$(domain):443 -showcerts -state -CAfile ca/cacert.pem >> /tmp/testresult 2>&1
 	@echo "get / HTTP/1.0" |$(OPENSSL) s_client -connect test2.$(domain):402 -showcerts -state -CAfile ca/cacert.pem >> /tmp/testresult 2>&1

--- a/bin/create-ec-ca.sh
+++ b/bin/create-ec-ca.sh
@@ -12,6 +12,4 @@ export ALTNAME=email:info@$DOMAIN
 # Create key
 openssl ecparam -out private/cakey.pem -genkey -name prime256v1
 # Create and sign request
-openssl req -x509 -new -key private/cakey.pem -days 3650 -extensions v3_ca -out cacert.pem
-
-
+openssl req -x509 -new -batch -key private/cakey.pem -days 3650 -extensions v3_ca -out cacert.pem

--- a/bin/createcert.sh
+++ b/bin/createcert.sh
@@ -217,7 +217,7 @@ openssl ecparam -out $KEYFILE -genkey \
 REQFILE=ca/ec/request/$FILENAME.req
 
 #openssl req -new -key $KEYFILE -out $REQFILE
-openssl req -new -nodes $REQOPTION \
+openssl req -new -batch -nodes $REQOPTION \
 	-out "$REQFILE" \
 	-key "$KEYFILE" \
 	-config etc/openssl.cnf
@@ -227,7 +227,7 @@ else
 # Keytype = RSA
 KEYFILE=ca/private/$FILENAME.key
 REQFILE=ca/request/$FILENAME.req
-openssl req -new -nodes $REQOPTION \
+openssl req -new -batch -nodes $REQOPTION \
 	-out "$REQFILE" \
 	-keyout "$KEYFILE" \
 	-config etc/openssl.cnf
@@ -239,7 +239,7 @@ fi
 	#-config etc/openssl.cnf \
 	#-out "ca/certs/$FILENAME.cert" \
 	#-infiles "$REQFILE"
-openssl ca  $OPTION \
+openssl ca -batch $OPTION \
 	-utf8 -cert $CACERT \
 	-config etc/openssl.cnf \
 	-out "certs/$FILENAME.cert" \

--- a/bin/createevilca.sh
+++ b/bin/createevilca.sh
@@ -10,6 +10,6 @@ touch index.txt
 export COMMONNAME=$DOMAIN
 export ALTNAME=DNS:$DOMAIN
 # Create keys and sign it with itself
-openssl req -new -x509 -newkey rsa:4096 -days 5026 -extensions v3_bad_ca -nodes \
+openssl req -new -x509 -batch -newkey rsa:4096 -days 5026 -extensions v3_bad_ca -nodes \
  -keyout private/cacert.key -out cacert.pem  \
  -config ../../etc/openssl.cnf

--- a/bin/createevilca.sh
+++ b/bin/createevilca.sh
@@ -6,7 +6,7 @@ export COMPANYNAME="The very trustworthy CA and used car sales inc"
 cd ca/bad
 mkdir -p certs private newcerts
 echo 1000 > serial
-touch index.txt
+: > index.txt
 export COMMONNAME=$DOMAIN
 export ALTNAME=DNS:$DOMAIN
 # Create keys and sign it with itself

--- a/httpd/test1/server.conf
+++ b/httpd/test1/server.conf
@@ -3,7 +3,7 @@
 ServerRoot "/etc/httpd"
 PidFile /var/run/httpd-test1.pid
 #Listen 12.34.56.78:80
-Listen 62.80.214.8:443
+Listen 443
 DocumentRoot "/usr/local/tls-o-matic/httpd/test1/www"
 
 include /usr/local/tls-o-matic/httpd/generic/server.include

--- a/httpd/test10/server.conf
+++ b/httpd/test10/server.conf
@@ -2,8 +2,8 @@
 ServerRoot "/etc/httpd"
 PidFile /var/run/httpd-test10.pid
 
-Listen 62.80.214.8:410
-Listen 62.80.214.8:60410
+Listen 410
+Listen 60410
 DocumentRoot "/usr/local/tls-o-matic/httpd/test10/www"
 
 include /usr/local/tls-o-matic/httpd/generic/server.include

--- a/httpd/test11/server.conf
+++ b/httpd/test11/server.conf
@@ -2,8 +2,8 @@
 ServerRoot "/etc/httpd"
 PidFile /var/run/httpd-test11.pid
 
-Listen 62.80.214.8:411
-Listen 62.80.214.8:60411
+Listen 411
+Listen 60411
 DocumentRoot "/usr/local/tls-o-matic/httpd/test11/www"
 
 include /usr/local/tls-o-matic/httpd/generic/server.include

--- a/httpd/test12/server.conf
+++ b/httpd/test12/server.conf
@@ -2,8 +2,8 @@
 ServerRoot "/etc/httpd"
 PidFile /var/run/httpd-test12.pid
 
-Listen 62.80.214.8:412
-Listen 62.80.214.8:60412
+Listen 412
+Listen 60412
 DocumentRoot "/usr/local/tls-o-matic/httpd/test12/www"
 
 include /usr/local/tls-o-matic/httpd/generic/server.include

--- a/httpd/test13/server.conf
+++ b/httpd/test13/server.conf
@@ -2,8 +2,8 @@
 ServerRoot "/etc/httpd"
 PidFile /var/run/httpd-test13.pid
 
-Listen 62.80.214.8:413
-Listen 62.80.214.8:60413
+Listen 413
+Listen 60413
 DocumentRoot "/usr/local/tls-o-matic/httpd/test13/www"
 
 include /usr/local/tls-o-matic/httpd/generic/server.include

--- a/httpd/test14/server.conf
+++ b/httpd/test14/server.conf
@@ -2,8 +2,8 @@
 ServerRoot "/etc/httpd"
 PidFile /var/run/httpd-test14.pid
 
-Listen 62.80.214.8:414
-Listen 62.80.214.8:60414
+Listen 414
+Listen 60414
 DocumentRoot "/usr/local/tls-o-matic/httpd/test14/www"
 
 include /usr/local/tls-o-matic/httpd/generic/server.include

--- a/httpd/test15/server.conf
+++ b/httpd/test15/server.conf
@@ -9,16 +9,12 @@ Listen 415
 Listen 60415
 
 # Listen for virtual host requests on all IP addresses
-NameVirtualHost 62.80.214.8
-
-# Go ahead and accept connections for these vhosts
-# from non-SNI clients
-SSLStrictSNIVHostCheck off
+NameVirtualHost *:415
 
 DocumentRoot "/usr/local/tls-o-matic/httpd/test15/www"
 
-#include /usr/local/tls-o-matic/httpd/generic/server.include
-include /usr/local/tls-o-matic/httpd/generic/server22.include
+include /usr/local/tls-o-matic/httpd/generic/server.include
+#include /usr/local/tls-o-matic/httpd/generic/server22.include
 
 SSLProtocol all -SSLv2
 SSLCipherSuite ALL:!ADH:!EXPORT:!SSLv2:RC4+RSA:+HIGH:+MEDIUM:+LOW
@@ -26,7 +22,11 @@ SSLCertificateKeyFile /usr/local/tls-o-matic/httpd/test15/test15.tls-o-matic.com
 SSLCertificateFile /usr/local/tls-o-matic/httpd/test15/test15.tls-o-matic.com.cert
 SSLCertificateChainFile /usr/local/tls-o-matic/httpd/test15/TLS-o-matic-intermediate-1.cert
 
-<VirtualHost 62.80.214.8:415>
+# Go ahead and accept connections for these vhosts
+# from non-SNI clients
+SSLStrictSNIVHostCheck off
+
+<VirtualHost *:415>
   # Because this virtual host is defined first, it will
   # be used as the default if the hostname is not received
   # in the SSL handshake, e.g. if the browser doesn't support
@@ -41,7 +41,7 @@ SSLCertificateChainFile /usr/local/tls-o-matic/httpd/test15/TLS-o-matic-intermed
 
 </VirtualHost>
 
-<VirtualHost 62.80.214.8:415>
+<VirtualHost *:415>
   DocumentRoot "/usr/local/tls-o-matic/httpd/test15/www-test15a"
   ServerName test15a.tls-o-matic.com
   SSLEngine on
@@ -51,7 +51,7 @@ SSLCertificateChainFile /usr/local/tls-o-matic/httpd/test15/TLS-o-matic-intermed
   SSLCertificateChainFile /usr/local/tls-o-matic/httpd/test15/TLS-o-matic-intermediate-1.cert
 </VirtualHost>
 
-<VirtualHost 62.80.214.8:415>
+<VirtualHost *:415>
   DocumentRoot "/usr/local/tls-o-matic/httpd/test15/www-test15b"
   ServerName test15b.tls-o-matic.com
   SSLEngine on

--- a/httpd/test15/server.conf
+++ b/httpd/test15/server.conf
@@ -5,8 +5,8 @@
 ServerRoot "/etc/httpd"
 PidFile /var/run/httpd-test15.pid
 
-Listen 62.80.214.8:415
-Listen 62.80.214.8:60415
+Listen 415
+Listen 60415
 
 # Listen for virtual host requests on all IP addresses
 NameVirtualHost 62.80.214.8

--- a/httpd/test16/server.conf
+++ b/httpd/test16/server.conf
@@ -5,7 +5,7 @@
 ServerRoot "/etc/httpd"
 PidFile /var/run/httpd-test16.pid
 
-Listen 62.80.214.8:416
+Listen 416
 
 # Listen for virtual host requests on all IP addresses
 NameVirtualHost 62.80.214.8:416

--- a/httpd/test16/server.conf
+++ b/httpd/test16/server.conf
@@ -8,23 +8,23 @@ PidFile /var/run/httpd-test16.pid
 Listen 416
 
 # Listen for virtual host requests on all IP addresses
-NameVirtualHost 62.80.214.8:416
-
-# Go ahead and accept connections for these vhosts
-# from non-SNI clients
-SSLStrictSNIVHostCheck off
+NameVirtualHost *:416
 
 DocumentRoot "/usr/local/tls-o-matic/httpd/test15/www"
 
-#include /usr/local/tls-o-matic/httpd/generic/server.include
-include /usr/local/tls-o-matic/httpd/generic/server22.include
+include /usr/local/tls-o-matic/httpd/generic/server.include
+#include /usr/local/tls-o-matic/httpd/generic/server22.include
 
 SSLProtocol all -SSLv2
 SSLCipherSuite ALL:!ADH:!EXPORT:!SSLv2:RC4+RSA:+HIGH:+MEDIUM:+LOW
 SSLCertificateKeyFile /usr/local/tls-o-matic/httpd/test15/test15.tls-o-matic.com.key
 SSLCertificateFile /usr/local/tls-o-matic/httpd/test15/test15.tls-o-matic.com.cert
 
-<VirtualHost 62.80.214.8:416>
+# Go ahead and accept connections for these vhosts
+# from non-SNI clients
+SSLStrictSNIVHostCheck off
+
+<VirtualHost *:416>
   # Because this virtual host is defined first, it will
   # be used as the default if the hostname is not received
   # in the SSL handshake, e.g. if the browser doesn't support

--- a/httpd/test17/server.conf
+++ b/httpd/test17/server.conf
@@ -5,8 +5,8 @@
 ServerRoot "/etc/httpd"
 PidFile /var/run/httpd-test17.pid
 
-Listen 62.80.214.8:417
-Listen 62.80.214.8:60417
+Listen 417
+Listen 60417
 
 # Go ahead and accept connections for these vhosts
 # from non-SNI clients

--- a/httpd/test17/server.conf
+++ b/httpd/test17/server.conf
@@ -8,14 +8,10 @@ PidFile /var/run/httpd-test17.pid
 Listen 417
 Listen 60417
 
-# Go ahead and accept connections for these vhosts
-# from non-SNI clients
-SSLStrictSNIVHostCheck off
-
 DocumentRoot "/usr/local/tls-o-matic/httpd/test17/www"
 
-#include /usr/local/tls-o-matic/httpd/generic/server.include
-include /usr/local/tls-o-matic/httpd/generic/server22.include
+include /usr/local/tls-o-matic/httpd/generic/server.include
+#include /usr/local/tls-o-matic/httpd/generic/server22.include
 
 SSLProtocol all -SSLv2
 SSLCipherSuite ALL:!ADH:!EXPORT:!SSLv2:RC4+RSA:+HIGH:+MEDIUM:+LOW
@@ -26,3 +22,7 @@ SSLEngine on
 
 SSLCertificateKeyFile /usr/local/tls-o-matic/httpd/test17/test17.tls-o-matic.com.key
 SSLCertificateFile /usr/local/tls-o-matic/httpd/test17/test17.tls-o-matic.com.cert
+
+# Go ahead and accept connections for these vhosts
+# from non-SNI clients
+SSLStrictSNIVHostCheck off

--- a/httpd/test2/server.conf
+++ b/httpd/test2/server.conf
@@ -2,8 +2,8 @@
 ServerRoot "/etc/httpd"
 PidFile /var/run/httpd-test2.pid
 
-Listen 62.80.214.8:402
-Listen 62.80.214.8:60402
+Listen 402
+Listen 60402
 DocumentRoot "/usr/local/tls-o-matic/httpd/test2/www"
 
 include /usr/local/tls-o-matic/httpd/generic/server.include

--- a/httpd/test20/server.conf
+++ b/httpd/test20/server.conf
@@ -1,12 +1,13 @@
 # TEST6 certificate from the future
 ServerRoot "/etc/httpd"
+ServerRoot "/usr/local/apache2"
 PidFile /var/run/httpd-test20.pid
 
 Listen 420
 Listen 60420
 DocumentRoot "/usr/local/tls-o-matic/httpd/test20/www"
 
-include /usr/local/tls-o-matic/httpd/generic/server22.include
+include /usr/local/tls-o-matic/httpd/generic/server.include
 
 ServerName test20.tls-o-matic.com
 SSLProtocol All -SSLv2 -SSLv3

--- a/httpd/test20/server.conf
+++ b/httpd/test20/server.conf
@@ -2,8 +2,8 @@
 ServerRoot "/etc/httpd"
 PidFile /var/run/httpd-test20.pid
 
-Listen 62.80.214.8:420
-Listen 62.80.214.8:60420
+Listen 420
+Listen 60420
 DocumentRoot "/usr/local/tls-o-matic/httpd/test20/www"
 
 include /usr/local/tls-o-matic/httpd/generic/server22.include

--- a/httpd/test21/server.conf
+++ b/httpd/test21/server.conf
@@ -2,8 +2,8 @@
 ServerRoot "/etc/httpd"
 PidFile /var/run/httpd-test21.pid
 
-Listen 62.80.214.8:421
-Listen 62.80.214.8:60421
+Listen 421
+Listen 60421
 DocumentRoot "/usr/local/tls-o-matic/httpd/test21/www"
 
 include /usr/local/tls-o-matic/httpd/generic/server.include

--- a/httpd/test22/server.conf
+++ b/httpd/test22/server.conf
@@ -3,8 +3,8 @@
 ServerRoot "/etc/httpd"
 PidFile /var/run/httpd-test22.pid
 
-Listen 62.80.214.8:422
-Listen 62.80.214.8:60422
+Listen 422
+Listen 60422
 DocumentRoot "/usr/local/tls-o-matic/httpd/test22/www"
 
 include /usr/local/tls-o-matic/httpd/generic/server.include

--- a/httpd/test3/server.conf
+++ b/httpd/test3/server.conf
@@ -2,8 +2,8 @@
 ServerRoot "/etc/httpd"
 PidFile /var/run/httpd-test3.pid
 
-Listen 62.80.214.8:403
-Listen 62.80.214.8:60403
+Listen 403
+Listen 60403
 DocumentRoot "/usr/local/tls-o-matic/httpd/test3/www"
 
 include /usr/local/tls-o-matic/httpd/generic/server.include

--- a/httpd/test30/server.conf
+++ b/httpd/test30/server.conf
@@ -4,8 +4,8 @@
 ServerRoot "/etc/httpd"
 PidFile /var/run/httpd-test30.pid
 
-Listen 62.80.214.8:430
-Listen 62.80.214.8:60430
+Listen 430
+Listen 60430
 
 # Listen for virtual host requests on all IP addresses
 

--- a/httpd/test30/server.conf
+++ b/httpd/test30/server.conf
@@ -9,14 +9,10 @@ Listen 60430
 
 # Listen for virtual host requests on all IP addresses
 
-# Go ahead and accept connections for these vhosts
-# from non-SNI clients
-SSLStrictSNIVHostCheck off
-
 DocumentRoot "/usr/local/tls-o-matic/httpd/test30/www"
 
-#include /usr/local/tls-o-matic/httpd/generic/server.include
-include /usr/local/tls-o-matic/httpd/generic/server22.include
+include /usr/local/tls-o-matic/httpd/generic/server.include
+#include /usr/local/tls-o-matic/httpd/generic/server22.include
 
 SSLProtocol all -SSLv2 -SSLv3
 SSLCipherSuite ALL:!ADH:!EXPORT:!SSLv2:RC4+RSA:+HIGH:+MEDIUM:+LOW
@@ -30,4 +26,6 @@ SSLCipherSuite ALL:!ADH:!EXPORT:!SSLv2:RC4+RSA:+HIGH:+MEDIUM:+LOW
   SSLCertificateKeyFile /usr/local/tls-o-matic/httpd/test30/test30.tls-o-matic.com.key
   SSLCertificateFile /usr/local/tls-o-matic/httpd/test30/test30.tls-o-matic.com.cert
 
-
+# Go ahead and accept connections for these vhosts
+# from non-SNI clients
+SSLStrictSNIVHostCheck off

--- a/httpd/test31/server.conf
+++ b/httpd/test31/server.conf
@@ -4,8 +4,8 @@
 ServerRoot "/etc/httpd"
 PidFile /var/run/httpd-test31.pid
 
-Listen 62.80.214.8:431
-Listen 62.80.214.8:60431
+Listen 431
+Listen 60431
 
 # Listen for virtual host requests on all IP addresses
 

--- a/httpd/test31/server.conf
+++ b/httpd/test31/server.conf
@@ -9,13 +9,9 @@ Listen 60431
 
 # Listen for virtual host requests on all IP addresses
 
-# Go ahead and accept connections for these vhosts
-# from non-SNI clients
-SSLStrictSNIVHostCheck off
 
-
-#include /usr/local/tls-o-matic/httpd/generic/server.include
-include /usr/local/tls-o-matic/httpd/generic/server22.include
+include /usr/local/tls-o-matic/httpd/generic/server.include
+#include /usr/local/tls-o-matic/httpd/generic/server22.include
 
 SSLProtocol all -SSLv2 -SSLv3
 SSLCipherSuite ALL:!ADH:!EXPORT:!SSLv2:RC4+RSA:+HIGH:+MEDIUM:+LOW
@@ -25,3 +21,7 @@ SSLEngine on
 
 SSLCertificateKeyFile /usr/local/tls-o-matic/httpd/test31/test31.tls-o-matic.com.key
 SSLCertificateFile /usr/local/tls-o-matic/httpd/test31/test31.tls-o-matic.com.cert
+
+# Go ahead and accept connections for these vhosts
+# from non-SNI clients
+SSLStrictSNIVHostCheck off

--- a/httpd/test32/server.conf
+++ b/httpd/test32/server.conf
@@ -9,8 +9,8 @@ Listen 60432
 
 DocumentRoot "/usr/local/tls-o-matic/httpd/test32/www"
 
-#include /usr/local/tls-o-matic/httpd/generic/server.include
-include /usr/local/tls-o-matic/httpd/generic/server22.include
+include /usr/local/tls-o-matic/httpd/generic/server.include
+#include /usr/local/tls-o-matic/httpd/generic/server22.include
 
 SSLProtocol all -SSLv2 -SSLv3
 SSLCipherSuite ALL:!ADH:!EXPORT:!SSLv2:RC4+RSA:+HIGH:+MEDIUM:+LOW

--- a/httpd/test32/server.conf
+++ b/httpd/test32/server.conf
@@ -4,8 +4,8 @@
 ServerRoot "/etc/httpd"
 PidFile /var/run/httpd-test32.pid
 
-Listen 62.80.214.8:432
-Listen 62.80.214.8:60432
+Listen 432
+Listen 60432
 
 DocumentRoot "/usr/local/tls-o-matic/httpd/test32/www"
 

--- a/httpd/test4/server.conf
+++ b/httpd/test4/server.conf
@@ -2,8 +2,8 @@
 ServerRoot "/etc/httpd"
 PidFile /var/run/httpd-test4.pid
 
-Listen 62.80.214.8:404
-Listen 62.80.214.8:60404
+Listen 404
+Listen 60404
 DocumentRoot "/usr/local/tls-o-matic/httpd/test4/www"
 
 include /usr/local/tls-o-matic/httpd/generic/server.include

--- a/httpd/test5/server.conf
+++ b/httpd/test5/server.conf
@@ -1,8 +1,8 @@
 ServerRoot "/etc/httpd"
 PidFile /var/run/httpd-test5.pid
 
-Listen 62.80.214.8:405
-Listen 62.80.214.8:60405
+Listen 405
+Listen 60405
 DocumentRoot "/usr/local/tls-o-matic/httpd/test5/www"
 
 include /usr/local/tls-o-matic/httpd/generic/server.include

--- a/httpd/test6/server.conf
+++ b/httpd/test6/server.conf
@@ -2,8 +2,8 @@
 ServerRoot "/etc/httpd"
 PidFile /var/run/httpd-test6.pid
 
-Listen 62.80.214.8:406
-Listen 62.80.214.8:60406
+Listen 406
+Listen 60406
 DocumentRoot "/usr/local/tls-o-matic/httpd/test6/www"
 
 include /usr/local/tls-o-matic/httpd/generic/server.include

--- a/httpd/test7/server.conf
+++ b/httpd/test7/server.conf
@@ -1,8 +1,8 @@
 ServerRoot "/etc/httpd"
 PidFile /var/run/httpd-test7.pid
 
-Listen 62.80.214.8:407
-Listen 62.80.214.8:60407
+Listen 407
+Listen 60407
 DocumentRoot "/usr/local/tls-o-matic/httpd/test7/www"
 
 include /usr/local/tls-o-matic/httpd/generic/server.include

--- a/httpd/test8/server.conf
+++ b/httpd/test8/server.conf
@@ -2,8 +2,8 @@
 ServerRoot "/etc/httpd"
 PidFile /var/run/httpd-test8.pid
 
-Listen 62.80.214.8:408
-Listen 62.80.214.8:60408
+Listen 408
+Listen 60408
 DocumentRoot "/usr/local/tls-o-matic/httpd/test8/www"
 
 include /usr/local/tls-o-matic/httpd/generic/server.include

--- a/httpd/test9/server.conf
+++ b/httpd/test9/server.conf
@@ -2,8 +2,8 @@
 ServerRoot "/etc/httpd"
 PidFile /var/run/httpd-test9.pid
 
-Listen 62.80.214.8:409
-Listen 62.80.214.8:60409
+Listen 409
+Listen 60409
 DocumentRoot "/usr/local/tls-o-matic/httpd/test9/www"
 
 include /usr/local/tls-o-matic/httpd/generic/server.include


### PR DESCRIPTION
With this patch, we can run tests on our own systems:
## How to run tests
1. Install CentOS 6.5 (if you are familiar with Vagrant,  run `vagrant init chef/centos-6.5`)
2. `yum install -y httpd mod_ssl gcc openssl-devel zlib-devel git`
3. Install Apache2 >= 2.2.24
   - ./configure --enable-mods-shared=all --enable-cache --enable-ssl
   - make
   - sudo make install
4. `git checkout tls-o-matic`
5. `make clean`
   - This step is required to remove root CA certificates.
6. `make certs`
7. `sudo make web`
8. **Test your TLS clients!**
   - You need to install `ca/cacert.pem` and `ca/ec/cacert.pem` to your clients
